### PR TITLE
Bump cmake_minimum_required to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(toxext)
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(INSTALL_MOCKS CACHE BOOL OFF)
 


### PR DESCRIPTION
* CMake is warning about < 2.8.12 going EOL