### PR TITLE
Fix memory corruption

### DIFF
--- a/src/toxext.c
+++ b/src/toxext.c
@@ -620,10 +620,12 @@ static void toxext_packet_list_free(struct ToxExtPacketList *packet_list)
 	 */
 	if (packet_list->toxext->num_deferred_packets &&
 	    *packet_list->toxext->deferred_packets == packet_list) {
+
 		/* Slide all elements back by one to preserve order */
-		memcpy(packet_list->toxext->deferred_packets,
+		memmove(packet_list->toxext->deferred_packets,
 		       packet_list->toxext->deferred_packets + 1,
-		       packet_list->toxext->num_deferred_packets - 1);
+		       (packet_list->toxext->num_deferred_packets - 1) *
+					sizeof(struct ToxExtPacketList*));
 
 		/* If we fail to realloc we can still just not use that item */
 		packet_list->toxext->num_deferred_packets--;

--- a/src/toxext.c
+++ b/src/toxext.c
@@ -462,12 +462,17 @@ void toxext_deregister(struct ToxExtExtension *extension)
 	/* Even if we fail to realloc after we can still reduce our size */
 	toxext->num_extensions--;
 
-	struct ToxExtExtension **new_extensions = realloc(
-		toxext->extensions,
-		toxext->num_extensions * sizeof(struct ToxExtExtension *));
+	if (toxext->num_extensions) {
+		struct ToxExtExtension **new_extensions = realloc(
+			toxext->extensions,
+			toxext->num_extensions * sizeof(struct ToxExtExtension *));
 
-	if (new_extensions || toxext->num_extensions == 0) {
-		toxext->extensions = new_extensions;
+		if (new_extensions) {
+			toxext->extensions = new_extensions;
+		}
+	} else {
+		free(toxext->extensions);
+		toxext->extensions = NULL;
 	}
 }
 
@@ -537,12 +542,17 @@ static void toxext_remove_connection(struct ToxExt *toxext,
 	/* If we fail to realloc we can still just not use that item */
 	toxext->num_connections--;
 
-	new_connections = realloc(toxext->connections,
-				  toxext->num_connections *
-					  sizeof(struct ToxExtConnection));
+	if (toxext->num_connections) {
+		new_connections = realloc(toxext->connections,
+					toxext->num_connections *
+						sizeof(struct ToxExtConnection));
 
-	if (new_connections || toxext->num_connections == 0) {
-		toxext->connections = new_connections;
+		if (new_connections) {
+			toxext->connections = new_connections;
+		}
+	} else {
+		free(toxext->connections);
+		toxext->connections = NULL;
 	}
 }
 
@@ -629,15 +639,20 @@ static void toxext_packet_list_free(struct ToxExtPacketList *packet_list)
 
 		/* If we fail to realloc we can still just not use that item */
 		packet_list->toxext->num_deferred_packets--;
-		/* Remove connection from list */
-		struct ToxExtPacketList **new_deferred_packets =
-			realloc(packet_list->toxext->deferred_packets,
-				packet_list->toxext->num_deferred_packets *
-					sizeof(struct ToxExtPacketList *));
 
-		if (new_deferred_packets ||
-		    packet_list->toxext->num_deferred_packets == 0) {
-			packet_list->toxext->deferred_packets = new_deferred_packets;
+		/* Remove connection from list */
+		if (packet_list->toxext->num_deferred_packets) {
+			struct ToxExtPacketList **new_deferred_packets =
+				realloc(packet_list->toxext->deferred_packets,
+					packet_list->toxext->num_deferred_packets *
+						sizeof(struct ToxExtPacketList *));
+
+			if (new_deferred_packets) {
+				packet_list->toxext->deferred_packets = new_deferred_packets;
+			}
+		} else {
+			free(packet_list->toxext->deferred_packets);
+			packet_list->toxext->deferred_packets = NULL;
 		}
 	}
 
@@ -1088,13 +1103,19 @@ int toxext_revoke_connection(struct ToxExtExtension *extension,
 
 	/* If we fail to realloc we can still just not use that item */
 	toxext->num_connections--;
-	/* Remove connection from list */
-	struct ToxExtConnection *new_connections = realloc(
-		toxext->connections,
-		toxext->num_connections * sizeof(struct ToxExtConnection));
 
-	if (new_connections || toxext->num_connections == 0) {
-		toxext->connections = new_connections;
+	if (toxext->num_connections) {
+		/* Remove connection from list */
+		struct ToxExtConnection *new_connections = realloc(
+			toxext->connections,
+			toxext->num_connections * sizeof(struct ToxExtConnection));
+
+		if (new_connections) {
+			toxext->connections = new_connections;
+		}
+	} else {
+		free(toxext->connections);
+		toxext->connections = NULL;
 	}
 
 	return TOXEXT_SUCCESS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,9 @@ set(REPORT_COVERAGE OFF CACHE BOOL "Generate coverage reports")
 # I'm sure I could do this better but I don't want to spend my time on cmake really
 function(toxext_test test_name)
 	add_executable(${test_name} ${ARGN})
+	target_compile_options(${test_name} PRIVATE -fsanitize=address)
+	target_link_options(${test_name} PRIVATE -fsanitize=address)
+
 	# we use gnu11 for the tests so we can use the container_of macro for inheritance a la linux
 	# Force _DEBUG for tests since we use the assert() macro to crash the tests
 if (REPORT_COVERAGE)
@@ -25,3 +28,4 @@ toxext_test(peer_sometimes_no_extension peer_sometimes_no_extension.c)
 toxext_test(mismatched_extension_ids mismatched_extension_ids.c)
 toxext_test(simple_extension_test simple_extension_test.c)
 toxext_test(multiple_big_packets multiple_big_packets.c)
+toxext_test(deferred_packets deferred_packets.c)

--- a/test/deferred_packets.c
+++ b/test/deferred_packets.c
@@ -1,0 +1,81 @@
+#include "mock_fixtures.h"
+#include "toxext.h"
+#include "mock_tox.h"
+
+#include "assert.h"
+
+static uint8_t my_extension_uuid[16] = { 0xab, 0xcd };
+
+static int num_received_messages = 0;
+
+void my_ext_recv_callback(struct ToxExtExtension *extension, uint32_t friend_id,
+			  void const *data_v, size_t size, void *userdata,
+			  struct ToxExtPacketList *response_packet)
+{
+	(void)extension;
+	(void)friend_id;
+	(void)data_v;
+	(void)size;
+	(void)userdata;
+	(void)response_packet;
+	num_received_messages++;
+}
+void my_ext_neg_callback(struct ToxExtExtension *extension, uint32_t friend_id,
+			 bool compatible, void *userdata,
+			 struct ToxExtPacketList *packet)
+{
+	(void)extension;
+	(void)friend_id;
+	(void)userdata;
+	(void)packet;
+	(void)compatible;
+}
+
+/* Test behavior of deferred packets */
+int main(void)
+{
+	struct ToxExtUser user_a;
+	toxext_test_init_tox_ext_user(&user_a);
+	struct ToxExtExtension *extension_a =
+		toxext_register(user_a.toxext, my_extension_uuid, NULL,
+				my_ext_recv_callback, my_ext_neg_callback);
+
+	struct ToxExtUser user_b;
+	toxext_test_init_tox_ext_user(&user_b);
+
+	toxext_register(user_b.toxext, my_extension_uuid, NULL,
+			my_ext_recv_callback, my_ext_neg_callback);
+
+	toxext_negotiate_connection(extension_a, user_b.tox_user.id);
+
+	/* Clear outstanding packets from negotiation */
+	tox_iterate(user_a.tox_user.tox, &user_a.tox_user);
+	tox_iterate(user_b.tox_user.tox, &user_b.tox_user);
+
+	/* Ensure that multiple packets will be deferred */
+	tox_set_sendq_size(user_b.tox_user.tox, 1);
+
+	/* Queue up 100 packets */
+	for (int i = 0; i < 100; ++i) {
+		struct ToxExtPacketList *packet_list =
+			toxext_packet_list_create(user_a.toxext,
+						  user_b.tox_user.id);
+		toxext_segment_append(packet_list, extension_a, NULL, 0);
+		toxext_send(packet_list);
+	}
+
+    /* Fire through the deferred packets */
+	for (int i = 0; i < 100; ++i) {
+		toxext_iterate(user_a.toxext);
+		tox_iterate(user_a.tox_user.tox, &user_a.tox_user);
+		tox_iterate(user_b.tox_user.tox, &user_b.tox_user);
+	}
+
+    /* And check that we got them all */
+	assert(num_received_messages == 100);
+
+	toxext_test_cleanup_tox_ext_user(&user_a);
+	toxext_test_cleanup_tox_ext_user(&user_b);
+
+	return 0;
+}


### PR DESCRIPTION
    Fix memory corruption in deferred lists

    This fixes two bugs.

    1. memcpy has undefined behavior when copying into overlapping memory
       regions.
    2. We accidentally were copying num_deferred_packet bytes instead of
       num_deferred_packet elements

    Switch to memmove which has defined behavior for overlapping memory
    regions and fix the copy size.